### PR TITLE
Add support for claiming badge through reusable code

### DIFF
--- a/lib/cd-badges.js
+++ b/lib/cd-badges.js
@@ -32,7 +32,7 @@ module.exports = function () {
   seneca.add({role: plugin, cmd: 'acceptBadge'}, acceptBadge.bind(seneca));
   seneca.add({role: plugin, cmd: 'loadUserBadges'}, loadUserBadges.bind(seneca));
   seneca.add({role: plugin, cmd: 'loadBadgeCategories'}, loadBadgeCategories);
-  seneca.add({role: plugin, cmd: 'loadBadgeByCode'}, loadBadgeByCode.bind(seneca));
+  seneca.add({role: plugin, cmd: 'loadBadgeByCode'}, loadBadgeByCode({ apiBaseUrl: options.apiBaseUrl, apiSecret: options.apiSecret}));
   seneca.add({role: plugin, cmd: 'claimBadge'}, claimBadge.bind(seneca));
   seneca.add({role: plugin, cmd: 'addBadgeToProfile'}, addBadgeToProfile.bind(seneca));
   seneca.add({role: plugin, cmd: 'exportBadges'}, exportBadges.bind(seneca));

--- a/lib/claim-badge.js
+++ b/lib/claim-badge.js
@@ -14,15 +14,6 @@ function claimBadge (args, callback) {
   badge.status = 'accepted';
   badge.dateAccepted = new Date();
 
-  // Remove code tag from badge tags so it doesn't show up on user profile page.
-  // TODO - this is not good _ usage, needs to be refactored!!
-  var indexFound;
-  _.find(badge.tags, function (tag, index) {
-    indexFound = index;
-    return _.contains(tag.value, claimCodePrefix);
-  });
-  badge.tags.splice(indexFound, 1);
-
   seneca.act({role: 'cd-profiles', cmd: 'list', query: {userId: requestingUser.id}}, function (err, response) {
     if (err) return callback(err);
     seneca.act({role: plugin, cmd: 'addBadgeToProfile', profile: response[0], badge: badge}, function (err, response) {

--- a/lib/list-badges.js
+++ b/lib/list-badges.js
@@ -18,7 +18,6 @@ module.exports = function (options) {
     }
     var claimCodePrefix = options.claimCodePrefix;
     var resource = '/systems/coderdojo/badges';
-
     var requestOptions = {
       uri: resource,
       method: 'GET',

--- a/lib/load-badge-by-code.js
+++ b/lib/load-badge-by-code.js
@@ -1,23 +1,45 @@
 'use strict';
 
+var request = require('request');
+var getToken = require('./utils/get-token');
 var _ = require('lodash');
 
-function loadBadgeByCode (args, callback) {
-  var seneca = this;
-  var plugin = args.role;
-  var code = args.code;
-
-  // Call the listBadges command with clientRequest set to false
-  // to ensure that the tags containing the badge code prefix are not filtered out.
-  seneca.act({role: plugin, cmd: 'listBadges'}, {clientRequest: false}, function (err, response) {
-    if (err) return callback(null, {error: err});
-    var badgeByCode = _.find(response.badges, function (badge) {
-      return _.find(badge.tags, function (tag) {
-        return tag.value === code;
-      });
-    });
-    return callback(null, {badge: badgeByCode});
+module.exports = function (options) {
+  var apiBaseUrl = options.apiBaseUrl;
+  var apiSecret = options.apiSecret;
+  var requestWithDefaults = request.defaults({
+    baseUrl: apiBaseUrl
   });
-}
 
-module.exports = loadBadgeByCode;
+  function loadBadgeByCode (args, callback) {
+    var code = args.code;
+    var clientRequest = args.clientRequest;
+    if (typeof clientRequest === 'undefined') {
+      clientRequest = true;
+    }
+    var resource = '/systems/coderdojo/codes/' + code;
+    var requestOptions = {
+      uri: resource,
+      method: 'GET',
+      headers: {
+        'Authorization': 'JWT token="' + getToken(resource, apiSecret) + '"'
+      }
+    };
+
+    function cb (error, response, body) {
+      if (typeof body === 'string') {
+        try {
+          body = JSON.parse(body);
+        } catch (e) {
+          return callback(e);
+        }
+      }
+      if (!error && response.statusCode === 200) {
+        return callback(null, body);
+      }
+      return callback(error || new Error(body.message));
+    }
+    requestWithDefaults(requestOptions, cb);
+  }
+  return loadBadgeByCode;
+};


### PR DESCRIPTION
as by badgekit definition

Claim code still needs to be inserted manually into DB until we do make a PR on openbadgekit to do it thourgh their interface (our ours, whatever)