### PR TITLE
Replace git:// protocol with https:// in package.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/CoderDojo/cp-badges-service.git"
+    "url": "https://github.com/CoderDojo/cp-badges-service.git"
   },
   "author": "CoderDojo Foundation",
   "license": "MIT",
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "async": "1.3.0",
-    "cp-logs-lib": "git://github.com/CoderDojo/cp-logs-lib#1.1.0",
-    "cp-permissions-plugin": "git://github.com/CoderDojo/cp-permissions-plugin#1.0.2",
+    "cp-logs-lib": "https://github.com/CoderDojo/cp-logs-lib#1.1.0",
+    "cp-permissions-plugin": "https://github.com/CoderDojo/cp-permissions-plugin#1.0.2",
     "jws": "3.0.0",
     "le_node": "1.1.0",
     "lodash": "3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -850,17 +850,17 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cp-logs-lib@git://github.com/CoderDojo/cp-logs-lib#1.1.0":
+"cp-logs-lib@https://github.com/CoderDojo/cp-logs-lib#1.1.0":
   version "1.1.0"
-  resolved "git://github.com/CoderDojo/cp-logs-lib#5c65480d0605546cf65e6f9b9b3de5ca26b43317"
+  resolved "https://github.com/CoderDojo/cp-logs-lib#5c65480d0605546cf65e6f9b9b3de5ca26b43317"
   dependencies:
     bunyan "1.8.1"
     le_node "1.4"
     lodash "4.13.1"
 
-"cp-permissions-plugin@git://github.com/CoderDojo/cp-permissions-plugin#1.0.2":
+"cp-permissions-plugin@https://github.com/CoderDojo/cp-permissions-plugin#1.0.2":
   version "1.0.2"
-  resolved "git://github.com/CoderDojo/cp-permissions-plugin#95c507a0cd47842755652605b849c2699d28dacf"
+  resolved "https://github.com/CoderDojo/cp-permissions-plugin#95c507a0cd47842755652605b849c2699d28dacf"
   dependencies:
     async "^2.0.0-rc.5"
     lodash "^4.13.1"


### PR DESCRIPTION
Github have discontinued support for the `git://` protocol.